### PR TITLE
Alex012724: Refactored user model schema using separate identification and address schemas.

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -1,23 +1,56 @@
-const { model, Schema } = require('mongoose')
+const { model, Schema } = require("mongoose");
 
-const userSchema = new Schema({
+const identificationSchema = new Schema({
+  identificationType: {
+    type: String,
+    required: true,
+    enum: [
+      "US Voter Registration",
+      "PR Voter Registration",
+      "US Passport",
+      "US License",
+      "PR Licence",
+    ],
+  },
+  identificationNumber: {
+    type: String,
+    required: true,
+    // unique: true
+  },
+});
 
-    fullName: {type: String, trim: true},
-    email: {type: String, required: true, trim: true},
-    password: {type: String, required: true, trim: true},
+const addressSchema = new Schema({
+    street: { type: String, trim: true },
+    city: { type: String, trim: true },
+    state: { type: String, trim: true },
+    zip: { type: String, trim: true }
+  });
+
+const userSchema = new Schema(
+  {
+    fullName: { type: String, trim: true },
+    email: { type: String, required: true, trim: true },
+    password: { type: String, required: true, trim: true },
     userName: String,
     phoneNumber: String,
-    address: Object,
-    voterRegistrationNumber: String,
-    driversLicenseNumber: String,
-    usPassportNumber: String,
+    address: addressSchema,
+    identification: identificationSchema,
     volunteer: Boolean,
-    donations: [{type: Schema.Types.ObjectId, ref: "Donation"}],
-    eventsAttended: [{type: Schema.Types.ObjectId, ref: "Event"}]
+    donations: [{ type: Schema.Types.ObjectId, ref: "Donation" }],
+    eventsAttended: [{ type: Schema.Types.ObjectId, ref: "Event" }],
+  },
+  {
+    timestamps: true,
+  }
+);
 
-},
-{
-    timestamps: true
-})
+const User = model("User", userSchema);
+const Identification = model("Identification", identificationSchema);
+const Address = model("Address", addressSchema);
 
-module.exports = model("User", userSchema)
+
+module.exports = {
+  User,
+  Identification,
+  Address
+};

--- a/models/User.js
+++ b/models/User.js
@@ -2,9 +2,9 @@ const { model, Schema } = require('mongoose')
 
 const userSchema = new Schema({
 
-    fullName: String,
-    email: String,
-    password: String,
+    fullName: {type: String, trim: true},
+    email: {type: String, required: true, trim: true},
+    password: {type: String, required: true, trim: true},
     userName: String,
     phoneNumber: String,
     address: Object,


### PR DESCRIPTION
I modified the User Schema so that it has a few sub schemas to manage identification and address so that they are both stored in an object format. I included the address in this change since we wanted both the identification and address to be stored as an object format I thought I might as well do include it in the change.